### PR TITLE
fix: typo in `--state` argument description

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -92,7 +92,7 @@ pub struct NodeArgs {
     #[clap(long, value_name = "PATH", value_parser = Genesis::parse)]
     pub init: Option<Genesis>,
 
-    /// This is an alias for bot --load-state and --dump-state.
+    /// This is an alias for both --load-state and --dump-state.
     ///
     /// It initializes the chain with the state stored at the file, if it exists, and dumps the
     /// chain's state on exit.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
There is a typo in `--state` argument description. This small PR fixes it 😁

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The `bot` word in `This is an alias for bot --load-state and --dump-state.` was changed to `both`.

I'm not sure if changing comment in this place fixes output of `anvil --help`. If there are any other places to fix, please let me know 🚀 .